### PR TITLE
Fix small namespace and 'extends' error

### DIFF
--- a/Controller/RootController.php
+++ b/Controller/RootController.php
@@ -5,7 +5,7 @@ namespace Newsletter2Go\Newsletter2Go\Controller;
 use OxidEsales\Eshop\Application\Controller\FrontendController;
 use OxidEsales\Eshop\Core\Utils;
 use Newsletter2Go\Newsletter2Go\Helper\Nl2GoResponseHelper;
-use OxidEsales\EshopCommunity\Core\Request;
+use OxidEsales\Eshop\Core\Request;
 
 class RootController extends FrontendController
 {

--- a/Core/Nl2GoSettings.php
+++ b/Core/Nl2GoSettings.php
@@ -3,9 +3,8 @@
 namespace Newsletter2Go\Newsletter2Go\Core;
 
 use OxidEsales\Eshop\Core\Registry;
-use \OxidEsales\EshopCommunity\Application\Controller\Admin\ModuleConfiguration;
 
-class Nl2GoSettings extends ModuleConfiguration
+class Nl2GoSettings extends Nl2GoSettings_parent
 {
     const N2GO_INTEGRATION_URL = 'https://ui.newsletter2go.com/integrations/connect/OX6/';
 


### PR DESCRIPTION
- Fixed wrong namespace in Controller/RootController.php (could cause problems in PE/EE shops)
- Fixed wrong 'extends' in Core/Nl2GoSettings.php (previous 'extends' interrupts the module-chain)